### PR TITLE
Introduce dirs.base.data_local helper

### DIFF
--- a/docs/docs/configuration/templating.md
+++ b/docs/docs/configuration/templating.md
@@ -38,6 +38,7 @@ This allows for e.g. access to environment variables.
 |-------------------|
 | `dirs.base.cache`      |
 | `dirs.base.config`     |
+| `dirs.base.config_local` |
 | `dirs.base.data`       |
 | `dirs.base.data_local` |
 | `dirs.base.home`       |

--- a/src/templating/mod.rs
+++ b/src/templating/mod.rs
@@ -81,6 +81,7 @@ pub static DIRECTORY_PRAMETERS: LazyLock<DirectoryPrameters> = LazyLock::new(|| 
   if let Some(dirs) = BaseDirs::new() {
     base.insert("cache", dirs.cache_dir().to_path_buf());
     base.insert("config", dirs.config_dir().to_path_buf());
+    base.insert("config_local", dirs.config_local_dir().to_path_buf());
     base.insert("data", dirs.data_dir().to_path_buf());
     base.insert("data_local", dirs.data_local_dir().to_path_buf());
     base.insert("home", dirs.home_dir().to_path_buf());


### PR DESCRIPTION
Thank you for the project. The design seems to fit quite nicely with my current `dot-files` setup.

I'd like to propose adding a new function to help setup `neovim` easier across
Windows and Linux/MacOS without having to rely on the per-platform path
declaration.

This PR introduces the `dirs.base.data_local` helper as a templating
function.

This exposes `directories` [config_local_dir()](https://docs.rs/directories/latest/directories/struct.BaseDirs.html#method.config_local_dir) for using in templating

 |Platform | Value                                 | Example                                  |
 | ------- | ------------------------------------- | ---------------------------------------- |
 | Linux   | `$XDG_CONFIG_HOME` or `$HOME`/.config | /home/alice/.config                      |
 | macOS   | `$HOME`/Library/Application Support   | /Users/Alice/Library/Application Support |
 | Windows | `{FOLDERID_LocalAppData}`             | C:\Users\Alice\AppData\Local             |

This is useful for using specially in `nvim` to setup cross-platform config.

```yaml
global:
  links:
    nvim: {{ dirs.base.data_local }}/nvim
```

This should expand to `~/.config/nvim` in Linux and MacOS, as well as `%USERPROFILE/AppData/Local/nvim` on Windows.
