### PR TITLE
Fix Clippy current clippy warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ use_self = { level = "allow", priority = 1 }
 default_trait_access = { level = "allow", priority = 1 }
 redundant_pub_crate = { level = "allow", priority = 1 }
 filetype_is_file = { level = "warn", priority = 1 }
-string_to_string = { level = "warn", priority = 1 }
+implicit_clone = { level = "warn", priority = 1 }
 unneeded_field_pattern = { level = "warn", priority = 1 }
 self_named_module_files = { level = "warn", priority = 1 }
 str_to_string = { level = "warn", priority = 1 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -83,7 +83,7 @@ impl Dots {
   #[cfg_attr(feature = "profiling", instrument)]
   fn add_root(&self) -> Self {
     Self {
-      dots: self.dots.iter().map(|d| if d.starts_with('/') { d.to_string() } else { format!("/{d}") }).collect_vec(),
+      dots: self.dots.iter().map(|d| if d.starts_with('/') { d.clone() } else { format!("/{d}") }).collect_vec(),
     }
   }
 }

--- a/src/commands/clone.rs
+++ b/src/commands/clone.rs
@@ -53,7 +53,7 @@ impl Command for Clone {
       Attribute::Reset
     );
 
-    helpers::run_command("git", &[OsStr::new("clone"), OsStr::new(&repo), self.config.dotfiles.as_os_str()], false, cli.dry_run)?;
+    helpers::run_command("git", &[OsStr::new("clone"), OsStr::new(&repo), self.config.dotfiles.as_os_str()], false, cli.dry_run).map_err(Error::CloneExecute)?;
 
     println!("\n{}Cloned repo{}", Attribute::Bold, Attribute::Reset);
 

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -141,10 +141,10 @@ impl<'b> Install<'b> {
       println!("{}{inner_cmd}{}\n", Attribute::Italic, Attribute::Reset);
 
       if let Err(err) = helpers::run_command(&cmd[0], &cmd[1..], false, globals.dry_run) {
-        if let helpers::RunError::Spawn(err) = &err {
-          if err.kind() == std::io::ErrorKind::NotFound {
-            eprintln!("\n Error: {:?}", Report::new(Error::CouldNotSpawn(format!("{:?}", self.config.shell_command))));
-          }
+        if let helpers::RunError::Spawn(err) = &err
+          && err.kind() == std::io::ErrorKind::NotFound
+        {
+          eprintln!("\n Error: {:?}", Report::new(Error::CouldNotSpawn(format!("{:?}", self.config.shell_command))));
         }
 
         let error = Error::InstallExecute(entry.0.clone(), err);
@@ -159,10 +159,10 @@ impl<'b> Install<'b> {
       installed.insert(entry.0.as_str());
     }
 
-    if !(install_command.skip_all_dependencies || install_command.skip_dependencies) {
-      if let Some(depends) = &entry.1.1 {
-        recurse!(depends, CyclicDependency);
-      }
+    if !(install_command.skip_all_dependencies || install_command.skip_dependencies)
+      && let Some(depends) = &entry.1.1
+    {
+      recurse!(depends, CyclicDependency);
     }
 
     ().pipe(Ok)

--- a/src/commands/link.rs
+++ b/src/commands/link.rs
@@ -83,13 +83,13 @@ impl<'a> Command for Link<'a> {
         for (to, from) in links {
           if !current_links.contains(to) {
             let mut removed = true;
-            if !globals.dry_run {
-              if let Err(err) = fs::remove_file(to) {
-                removed = false;
+            if !globals.dry_run
+              && let Err(err) = fs::remove_file(to)
+            {
+              removed = false;
 
-                if err.kind() != std::io::ErrorKind::NotFound {
-                  errors.push(Error::RemovingOrphan(from.clone(), to.clone(), err));
-                }
+              if err.kind() != std::io::ErrorKind::NotFound {
+                errors.push(Error::RemovingOrphan(from.clone(), to.clone(), err));
               }
             }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -182,23 +182,23 @@ pub enum Error {
 pub fn create_config_file(dotfiles: Option<&Path>, config_file: &Path) -> Result<(), Error> {
   let format = config_file.try_conv::<FileFormat>()?;
 
-  if let Ok(existing_config_str) = fs::read_to_string(config_file) {
-    if let Ok(existing_config) = deserialize_config(&existing_config_str, format) {
-      let mut errors: Vec<AlreadyExistsError> = vec![];
+  if let Ok(existing_config_str) = fs::read_to_string(config_file)
+    && let Ok(existing_config) = deserialize_config(&existing_config_str, format)
+  {
+    let mut errors: Vec<AlreadyExistsError> = vec![];
 
-      if let Some(dotfiles) = dotfiles {
-        if existing_config.dotfiles != dotfiles {
-          errors.push(AlreadyExistsError::new("dotfiles", &existing_config_str));
-        }
-      }
-
-      return Error::AlreadyExists(
-        errors.is_empty().then(|| (0, existing_config_str.len()).into()),
-        NamedSource::new(config_file.to_string_lossy(), existing_config_str),
-        errors,
-      )
-      .pipe(Err);
+    if let Some(dotfiles) = dotfiles
+      && existing_config.dotfiles != dotfiles
+    {
+      errors.push(AlreadyExistsError::new("dotfiles", &existing_config_str));
     }
+
+    return Error::AlreadyExists(
+      errors.is_empty().then(|| (0, existing_config_str.len()).into()),
+      NamedSource::new(config_file.to_string_lossy(), existing_config_str),
+      errors,
+    )
+    .pipe(Err);
   }
 
   let mut map = HashMap::new();

--- a/src/dot/error.rs
+++ b/src/dot/error.rs
@@ -29,7 +29,7 @@ pub enum Error {
     #[label] SourceSpan,
     #[source]
     #[diagnostic_source]
-    templating::Error,
+    templating::BoxedError,
   ),
 
   #[error("Io Error on file \"{0}\"")]

--- a/src/dot/mod.rs
+++ b/src/dot/mod.rs
@@ -104,7 +104,7 @@ pub(crate) fn read_dots(dotfiles_path: &Path, dots: &[String], config: &Config, 
       let text = match engine.render(&text, &parameters) {
         Ok(text) => text,
         Err(err) => {
-          return Error::RenderDot(NamedSource::new(format!("{name}/dot.{format}"), text.clone()), (0, text.len()).into(), err)
+          return Error::RenderDot(NamedSource::new(format!("{name}/dot.{format}"), text.clone()), (0, text.len()).into(), err.into())
             .pipe(Err)
             .into();
         }
@@ -116,18 +116,16 @@ pub(crate) fn read_dots(dotfiles_path: &Path, dots: &[String], config: &Config, 
             Ok(parsed) => match CapabilitiesCanonical::from(parsed, engine, &parameters) {
               Ok(ok) => ok,
               Err(err) => {
-                return Error::ParseDot(NamedSource::new(defaults, defaults.to_string()), (0, defaults.len()).into(), vec![err])
-                  .pipe(Err)
-                  .into();
+                return Error::ParseDot(NamedSource::new(defaults, defaults.clone()), (0, defaults.len()).into(), vec![err]).pipe(Err).into();
               }
             }
             .into(),
             Err(err) => {
-              return Error::ParseDot(NamedSource::new(defaults, defaults.to_string()), (0, defaults.len()).into(), err).pipe(Err).into();
+              return Error::ParseDot(NamedSource::new(defaults, defaults.clone()), (0, defaults.len()).into(), err).pipe(Err).into();
             }
           },
           Err(err) => {
-            return Error::RenderDot(NamedSource::new(format!("{name}/dot.{format}"), defaults.to_string()), (0, defaults.len()).into(), err)
+            return Error::RenderDot(NamedSource::new(format!("{name}/dot.{format}"), defaults.clone()), (0, defaults.len()).into(), err.into())
               .pipe(Err)
               .into();
           }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -127,7 +127,7 @@ pub enum GlobError {
 pub fn glob_from_vec(from: &[String], postfix: Option<&str>) -> miette::Result<Any<'static>> {
   from
     .iter()
-    .map(|g| postfix.map_or_else(|| g.to_string(), |postfix| format!("{g}{postfix}")))
+    .map(|g| postfix.map_or_else(|| g.clone(), |postfix| format!("{g}{postfix}")))
     .map(|g| Glob::new(&g).map(Glob::into_owned).map_err(GlobError::Build))
     .collect_vec()
     .pipe(join_err_result)?

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,11 +68,11 @@ pub enum Error {
 
   #[error("Cloud not parse config")]
   #[diagnostic(code(config::parse), help("Is the config file in the correct format?"))]
-  ParsingConfig(#[source] figment::Error),
+  ParsingConfig(#[source] Box<figment::Error>),
 
   #[error("Cloud not parse config")]
   #[diagnostic(code(config::local::parse), help("Did you provide a top level \"global\" key in the repo level config?"))]
-  RepoConfigProfile(#[source] figment::Error),
+  RepoConfigProfile(#[source] Box<figment::Error>),
 
   #[error("Default profile not allowed in config")]
   #[diagnostic(code(config::local::default), help("Change the top level \"default\" key in the repo level config to \"global\""))]
@@ -189,7 +189,7 @@ fn read_config(cli: &Cli) -> Result<Config, Error> {
 
   let mut figment = Figment::new().merge_from_path(&config_path, false)?.merge(env_config).merge(cli);
 
-  let config: Config = figment.clone().join(Config::default()).extract().map_err(Error::ParsingConfig)?;
+  let config: Config = figment.clone().join(Config::default()).extract().map_err(Box::from).map_err(Error::ParsingConfig)?;
 
   let dotfiles = helpers::resolve_home(&config.dotfiles);
 
@@ -201,6 +201,7 @@ fn read_config(cli: &Cli) -> Result<Config, Error> {
     .join(Config::default())
     .select(os::OS.to_string().to_ascii_lowercase())
     .extract()
+    .map_err(Box::from)
     .map_err(Error::RepoConfigProfile)?;
 
   config.dotfiles = helpers::resolve_home(&config.dotfiles);

--- a/src/templating/mod.rs
+++ b/src/templating/mod.rs
@@ -38,6 +38,21 @@ pub enum Error {
   ),
 }
 
+#[derive(thiserror::Error, Diagnostic, Debug)]
+#[error(transparent)]
+#[diagnostic(transparent)]
+// Boxed variant to avoid returning large error struct
+// as reported by Clippy. Necessary as miette don't implement
+// a blanket impl Diagnostic<Box<T>> for T : Diagnostic
+// so it uses transparent repr for derives
+pub struct BoxedError(Box<Error>);
+
+impl From<Error> for BoxedError {
+  fn from(value: Error) -> Self {
+    BoxedError(value.into())
+  }
+}
+
 #[derive(Serialize, Debug)]
 pub struct Parameters<'a> {
   pub config: &'a Config,


### PR DESCRIPTION
Running `cargo clippy` in 2026 brings in some errors now that it's a bit more
advanced on some rules, and includes additional linters since the last project
commit.

This commit clears up `cargo clippy` to unblock the CI.
