### PR TITLE
feat: optmize release binary optmize

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,3 +107,9 @@ unneeded_field_pattern = { level = "warn", priority = 1 }
 self_named_module_files = { level = "warn", priority = 1 }
 str_to_string = { level = "warn", priority = 1 }
 as_conversions = { level = "warn", priority = 1 }
+
+[profile.release]
+strip = true  # Automatically strip symbols from the binary.
+opt-level = "z"  # Optimize for size.
+lto = true
+codegen-units = 1


### PR DESCRIPTION
Using <https://github.com/johnthagen/min-sized-rust> as reference to reduce the binary size, results in ~50% reduction size (from 11Mb to 4.5Mb).