### PR TITLE
feat: pre-compile Android binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,11 @@ jobs:
             runner: macos-latest
             compile: native
 
+          - triple: aarch64-linux-android
+            filename: rotz
+            runner: ubuntu-latest
+            compile: cross
+
     steps:
       - uses: actions/checkout@v4
 
@@ -180,7 +185,7 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-          key: ${{ runner.os }}
+          key: ${{ runner.os }}-${{ matrix.target.triple }}
 
       - run: cargo install cross --git https://github.com/cross-rs/cross
         if: matrix.target.compile == 'cross'


### PR DESCRIPTION
To avoid errors with GCLib versions on pre-build scripts on dependencies to find the native GLib version instead of version from `cross` [ref] each triple will have it's own cache now

[ref]: <https://github.com/cross-rs/cross/issues/724>